### PR TITLE
Added modern exception -based error system for Stroll

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_23" default="true" project-jdk-name="23" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/stroll-script-python.iml" filepath="$PROJECT_DIR$/.idea/stroll-script-python.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/stroll-script-python.iml
+++ b/.idea/stroll-script-python.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/stroll/src/errors.py
+++ b/stroll/src/errors.py
@@ -1,22 +1,99 @@
 import os
-from colorama import Style, Back, Fore, init
-init()
+from colorama import Style, Fore, init
+init(autoreset=True)
+
+
+# Legacy error classes (old system)
+# Kept so old code does not break.
+
+
 class Syntaxerror:
     def __init__(self, msg):
         self.msg = msg
     def __repr__(self):
-        return Fore.RED + f'Syntax error  -> {self.msg}!' + Style.RESET_ALL
+        return Fore.RED + f'Syntax error -> {self.msg}!' + Style.RESET_ALL
+
 class Extensionerror:
     def __init__(self, filename, msg):
         self.filename = filename
         self.msg = msg
     def __repr__(self):
-        return Fore.RED + f'File extension error for file: {self.filename}, expected extension: ".bwt" -> {self.msg}!' + Style.RESET_ALL
+        return (
+            Fore.RED +
+            f'File extension error for: {self.filename}, expected .bwt -> {self.msg}!'
+            + Style.RESET_ALL
+        )
+
 class Miscerror:
     def __init__(self, msg):
         self.msg = msg
     def __repr__(self):
-        return Fore.RED + f'Misc error  -> {self.msg}!' + Style.RESET_ALL
+        return Fore.RED + f'Misc error -> {self.msg}!' + Style.RESET_ALL
+
+
+
+# New improved error system
+# Real Python exceptions with
+# optional line/column/token info.
+
+
+class StrollError(Exception):
+    def __init__(self, message, *, line=None, column=None, filename=None, token=None):
+        super().__init__(message)
+        self.message = message
+        self.line = line
+        self.column = column
+        self.filename = filename
+        self.token = token
+
+    def __str__(self):
+        text = Fore.RED + f"{self.__class__.__name__}: {self.message}"
+        # Show position info if available
+        if self.line is not None:
+            text += f" (line {self.line}"
+            if self.column is not None:
+                text += f", col {self.column}"
+            text += ")"
+        # Show token if available
+        if self.token:
+            text += f" [token: {self.token}]"
+        return text + Style.RESET_ALL
+
+    __repr__ = __str__
+
+
+# Simple subclasses so we can distinguish types of errors
+class SyntaxErrorStroll(StrollError): pass
+class ExtensionErrorStroll(StrollError): pass
+class MiscErrorStroll(StrollError): pass
+class NameErrorStroll(StrollError): pass
+class TypeErrorStroll(StrollError): pass
+class ArgumentErrorStroll(StrollError): pass
+class RuntimeErrorStroll(StrollError): pass
+
+
+
+# Helper to raise syntax errors
+# Parser/runtime can call this.
+
+
+def raise_syntax(message, token=None, *, filename=None):
+    line = getattr(token, "line", None)
+    col = getattr(token, "column", None)
+    val = getattr(token, "value", token)
+    raise SyntaxErrorStroll(
+        message,
+        line=line,
+        column=col,
+        filename=filename,
+        token=val
+    )
+
+
+# Old terminate() function
+# Still kept for compatibility.
+
+
 def terminate(token):
     print(Fore.YELLOW + f"On token: [ {token} ]" + Style.RESET_ALL)
     os._exit(1)


### PR DESCRIPTION
###  **PR Description**

This PR improves the error-handling system in Stroll by introducing real Python exception classes while keeping the old error objects intact for backward compatibility.

**What I changed**

Added a new StrollError base class that inherits from Python’s Exception.
Added specific exception subclasses like SyntaxErrorStroll, RuntimeErrorStroll, TypeErrorStroll, etc.
Added optional support for line, column, filename, and token information inside errors.
Added a raise_syntax() helper function to simplify throwing syntax errors from the parser.
Kept the old classes (Syntaxerror, Miscerror, Extensionerror) and terminate() to avoid breaking existing interpreter code.



**Why I made these changes**

The previous error classes were not real exceptions, so they couldn’t be raised or caught properly.
You used os._exit(1) which immediately kills execution, making the REPL and debugging difficult.
Adding structured exceptions lays the groundwork for better error messages, safer parsing, and a more reliable runtime.
Keeping the legacy system allows the project to transition gradually without breaking anything.

**Benefits**

You can handle errors more cleanly in the future (especially in the REPL).
Parser and runtime will be able to throw detailed errors with line/column info.
This makes future improvements (like better syntax errors, stack traces, and testing) much easier.
No breaking changes — existing code still works exactly the same.